### PR TITLE
- 제목 : <10/이슈이름 : 회원가입 오류 핫픽스>

### DIFF
--- a/src/main/java/shop/wannab/couponservice/coupon/service/CouponService.java
+++ b/src/main/java/shop/wannab/couponservice/coupon/service/CouponService.java
@@ -65,15 +65,13 @@ public class CouponService {
                         PolicyStatus.ACTIVE)
                 .orElseThrow(() -> new CouponException(CouponErrorCode.WELCOME_COUPON_POLICY_NOT_FOUND));
 
-        if (welcomePolicy == null) {
-            throw new CouponException(CouponErrorCode.COUPON_NOT_FOUND);
+        if (welcomePolicy != null) {
+            if (couponRepository.existsByUserIdAndCouponPolicy(userId, welcomePolicy)) {
+                throw new CouponException(CouponErrorCode.COUPON_ALREADY_ISSUED);
+            }
+            saveNewCoupon(userId, welcomePolicy, "WC");
         }
 
-        if (couponRepository.existsByUserIdAndCouponPolicy(userId, welcomePolicy)) {
-            throw new CouponException(CouponErrorCode.COUPON_ALREADY_ISSUED);
-        }
-
-        saveNewCoupon(userId, welcomePolicy, "WC");
     }
 
     @Transactional

--- a/src/main/java/shop/wannab/couponservice/couponpolicy/repository/PolicyTargetBookRepository.java
+++ b/src/main/java/shop/wannab/couponservice/couponpolicy/repository/PolicyTargetBookRepository.java
@@ -3,9 +3,12 @@ package shop.wannab.couponservice.couponpolicy.repository;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import shop.wannab.couponservice.couponpolicy.entity.PolicyStatus;
 import shop.wannab.couponservice.couponpolicy.entity.PolicyTargetBook;
 
 public interface PolicyTargetBookRepository extends JpaRepository<PolicyTargetBook, Long> {
     Optional<PolicyTargetBook> findByBookId(Long bookId);
     List<PolicyTargetBook> findAllByCouponPolicy_CouponPolicyIdIn(List<Long> policyIds);
+    Optional<PolicyTargetBook> findByBookIdAndCouponPolicy_PolicyStatus(Long categoryId, PolicyStatus status);
+
 }

--- a/src/main/java/shop/wannab/couponservice/couponpolicy/repository/PolicyTargetCategoryRepository.java
+++ b/src/main/java/shop/wannab/couponservice/couponpolicy/repository/PolicyTargetCategoryRepository.java
@@ -3,9 +3,10 @@ package shop.wannab.couponservice.couponpolicy.repository;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import shop.wannab.couponservice.couponpolicy.entity.PolicyStatus;
 import shop.wannab.couponservice.couponpolicy.entity.PolicyTargetCategory;
 
 public interface PolicyTargetCategoryRepository extends JpaRepository<PolicyTargetCategory, Long> {
-    Optional<PolicyTargetCategory> findByCategoryId(Long categoryId);
+    Optional<PolicyTargetCategory> findByCategoryIdAndCouponPolicy_PolicyStatus(Long categoryId, PolicyStatus status);
     List<PolicyTargetCategory> findAllByCouponPolicy_CouponPolicyIdIn(List<Long> policyIds);
 }

--- a/src/main/java/shop/wannab/couponservice/couponpolicy/service/couponcreator/BookCouponPolicyCreator.java
+++ b/src/main/java/shop/wannab/couponservice/couponpolicy/service/couponcreator/BookCouponPolicyCreator.java
@@ -32,7 +32,7 @@ public class BookCouponPolicyCreator implements CouponPolicyCreator {
             throw new CouponPolicyException(CouponPolicyErrorCode.INVALID_BOOK_ID);
         }
 
-        if (policyTargetBookRepository.findByBookId(bookId).isPresent()) {
+        if (policyTargetBookRepository.findByBookIdAndCouponPolicy_PolicyStatus(bookId,PolicyStatus.ACTIVE).isPresent()) {
             throw new CouponPolicyException(CouponPolicyErrorCode.BOOK_POLICY_ALREADY_EXISTS);
         }
 

--- a/src/main/java/shop/wannab/couponservice/couponpolicy/service/couponcreator/CategoryCouponPolicyCreator.java
+++ b/src/main/java/shop/wannab/couponservice/couponpolicy/service/couponcreator/CategoryCouponPolicyCreator.java
@@ -32,7 +32,7 @@ public class CategoryCouponPolicyCreator implements CouponPolicyCreator {
             throw new CouponPolicyException(CouponPolicyErrorCode.INVALID_CATEGORY_ID);
         }
 
-        if (policyTargetCategoryRepository.findByCategoryId(categoryId).isPresent()) {
+        if (policyTargetCategoryRepository.findByCategoryIdAndCouponPolicy_PolicyStatus(categoryId,PolicyStatus.ACTIVE).isPresent()) {
             throw new CouponPolicyException(CouponPolicyErrorCode.CATEGORY_POLICY_ALREADY_EXISTS);
         }
 


### PR DESCRIPTION
## 🥳 어떤 기능을 구현했나요?

> 회원가입 시 웰컴 쿠폰 정책이 없으면 회원가입이 안되던 오류 수정

## 🔎 작업 상세 내용

- [x] 회원가입 시 웰컴 쿠폰 정책이 없으면 회원가입이 안되던 오류 수정
- [x] 쿠폰 정책 등록 시 활성화된 쿠폰만 중복 생성이 안되어야 하는데 ID만 중복되면 안되던 문제 수정
      
## ⏰ Pull Request 마감시간
> 10일 오전 11시

## 📚 참고할만한 자료(선택)

## 🔗 관련 이슈
Closes #이슈번호
